### PR TITLE
Test PHP 7.2 and 7.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,8 @@
 language: php
 php:
   - 7.1
+  - 7.2
+  - 7.3
+install: composer install
+script:
+  - vendor/bin/phpunit


### PR DESCRIPTION
Intalling a particular version of phpunit is necessary because sometimes
Travis picks a version incompatible with the selected version of PHP.