### PR TITLE
Use GitHub Actions instead of Travis CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,19 +12,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        PHP_VERSION:
-          - 7.3
-          - 7.4
-          - 8.0
-    container:
-      image: "php:${{ matrix.PHP_VERSION }}"
+        php-versions: ['7.3', '7.4', '8.0']
     steps:  
-    - name: Download latest git
-      run: "add-apt-repository ppa:git-core/ppa && apt-get update && apt-get install -y git unzip"
-    - name: Download composer
-      run: "cd $(mktemp -d) && curl https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer"
-    - name: Install deps
-      run: "composer install"
-    - uses: actions/checkout@v2
-    - name: Tests
-      run:  ./vendor/bin/phpunit
+      - name: Checkout
+        uses: actions/checkout@v2
+
+      - name: Setup PHP and run tests
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php_versions }}
+          tools: phpunit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,30 @@
+name: Test
+"on":
+  push:
+    branches:
+      - master
+  pull_request:
+    types:
+      - opened
+      - synchronize
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        PHP_VERSION:
+          - 7.3
+          - 7.4
+          - 8.0
+    container:
+      image: "php:${{ matrix.PHP_VERSION }}"
+    steps:  
+    - name: Download latest git
+      run: "add-apt-repository ppa:git-core/ppa && apt-get update && apt-get install -y git unzip"
+    - name: Download composer
+      run: "cd $(mktemp -d) && curl https://getcomposer.org/installer | php -- --install-dir=/usr/local/bin --filename=composer"
+    - name: Install deps
+      run: "composer install"
+    - uses: actions/checkout@v2
+    - name: Tests
+      run:  ./vendor/bin/phpunit

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,8 +17,17 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
-      - name: Setup PHP and run tests
+      - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php_versions }}
-          tools: phpunit
+          php-version: ${{ matrix.php-versions }}
+          tools: phpunit,composer
+
+      - name: Setup problem matchers for PHPUnit
+        run: echo "::add-matcher::${{ runner.tool_cache }}/phpunit.json"
+
+      - name: Install Dependencies
+        run: composer install
+
+      - name: Run tests
+        run: ./vendor/bin/phpunit

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,0 @@
-language: php
-php:
-  - 7.3
-  - 7.4
-  - 8.0


### PR DESCRIPTION
Heyo long time no see 👋 

I've been playing around with GitHub Actions a little bit and thought it might be cool to have CI run right on GitHub instead of relying on something else like Travis.

The `test.yml` file basically reproduces the test matrix used in the travis.yml and setups up PHP/composer/phpunit so that the test suite is ran whenever
* master is merged
* PRs are opened
* PRs are updated

If y'all are cool with Travis feel free to close this 🙂